### PR TITLE
Only override Unset errors with a default

### DIFF
--- a/src/Env/Internal/Error.hs
+++ b/src/Env/Internal/Error.hs
@@ -8,6 +8,7 @@ module Env.Internal.Error
   , AsUnset(..)
   , AsEmpty(..)
   , AsUnread(..)
+  , defaultIfUnset
   ) where
 
 
@@ -28,6 +29,11 @@ data Error
 class AsUnset e where
   unset :: e
   tryUnset :: e -> Maybe ()
+
+defaultIfUnset :: AsUnset e => a -> e -> Either e a
+defaultIfUnset d e
+  | tryUnset e == Just () = Right d
+  | otherwise = Left e
 
 instance AsUnset Error where
   unset = UnsetError

--- a/test/EnvSpec.hs
+++ b/test/EnvSpec.hs
@@ -8,6 +8,7 @@ import           Control.Monad
 #if __GLASGOW_HASKELL__ < 710
 import           Data.Monoid (mempty)
 #endif
+import           Numeric.Natural
 import           Prelude hiding (pi)
 #if __GLASGOW_HASKELL__ >= 708
 import           System.Environment (lookupEnv, setEnv)
@@ -47,6 +48,9 @@ spec =
 
     it "looking for the non-existing env var selects the default flag value" $
       p (flag 4 7 "xyzzy" mempty) `shouldBe` Just 4
+
+    it "does not clobber an invalid value with the default" $
+      p (var auto "invalid-nat" (def 1)) `shouldBe` (Nothing :: Maybe Natural)
 
     context "readers" $ do
       it "can use a reader to parse the env var value" $
@@ -130,6 +134,7 @@ fancyEnv =
   , "num2"     ~> "7"
   , "yep"      ~> "!"
   , "empty"    ~> ""
+  , "invalid-nat" ~> "-1"
   ]
  where
   (~>) = (,)


### PR DESCRIPTION
Any set but invalid value should be preserved as an error, not silently
overridden with a default value. We can accomplish this by moving this
logic up into the Var's Reader, instead of on any opaque e in the
Parser.

Fixes #8.