### PR TITLE
Add varNameColumn, varHelpColumn and varHelpMaxColumns format options

### DIFF
--- a/example/FormatterOptions.hs
+++ b/example/FormatterOptions.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NamedFieldPuns #-}
+-- | Greetings for $NAME
+--
+-- @
+-- % NAME=a5579150 runhaskell -isrc example/Main.hs
+-- Hello, a5579150!
+-- % NAME=a5579150 QUIET=1 runhaskell -isrc example/Main.hs
+-- %
+-- @
+module Main (main) where
+
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative ((<$>), (<*>))
+#endif
+import Control.Monad (unless)
+import Env
+
+
+data Hello = Hello { name :: String, quiet :: Bool }
+
+main :: IO ()
+main = do
+  Hello {name, quiet} <- hello
+  unless quiet $
+    putStrLn ("Hello, " ++ name ++ "!")
+
+hello :: IO Hello
+hello = Env.parse (header "envparse example" . varHelpMaxColumns 99 . varNameColumn 2 . varHelpColumn 8) $
+  Hello <$> var (str <=< nonempty) "NAME"  (help "Target for the greeting. The greeting will say hello, comma, <NAME>, and a final exclamation")
+        <*> switch                 "QUIET" (help "Whether to actually print the greeting. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.")

--- a/src/Env.hs
+++ b/src/Env.hs
@@ -51,6 +51,9 @@ module Env
   , Help.header
   , Help.desc
   , Help.footer
+  , Help.varNameColumn
+  , Help.varHelpColumn
+  , Help.varHelpMaxColumns
   , Help.handleError
   , Help.ErrorHandler
   , Help.defaultErrorHandler


### PR DESCRIPTION
(Solves #14) At the end, adding just a bare field in Info to handle the number of columns felt wrong, so I ended up with `FormatOpts`, and implemented also some other options that are currently hardcoded: the start column of the variable name and the start column of the variable help. 

I've added an example file but I fear it is too dumb to be finally included as is. Any suggestion? Anyway, probably it's not really worth it.  