### PR TITLE
Remove note about def preventing failure

### DIFF
--- a/src/Env/Internal/Parser.hs
+++ b/src/Env/Internal/Parser.hs
@@ -254,8 +254,6 @@ defaultSensitive :: Bool
 defaultSensitive = False
 
 -- | The default value of the variable
---
--- /Note:/ specifying it means the parser won't ever fail.
 def :: a -> Mod Var a
 def d =
   Mod (\v -> v {varDef=Just d})


### PR DESCRIPTION
This was an outdated note and refers to behavior before 28bf50b, when
parse errors were replaced with default values.
